### PR TITLE
Symbol tables and compilation

### DIFF
--- a/mfst/__init__.py
+++ b/mfst/__init__.py
@@ -1106,8 +1106,9 @@ def compiler(strings,isymbols=None,osymbols=None,acceptor=False,add_symbols=True
         isymbols=SymbolTable(mutableOnFly=add_symbols)
         isymbols.add_symbol("-")
     if add_symbols and not acceptor and osymbols is None:
-        osymbols=isymbols   #  this is to handle bug in printing
-
+        osymbols=SymbolTable(mutableOnFly=add_symbols)   #  this is to handle bug in printing
+        osymbols.add_symbol("-")
+        
     if (acceptor):
         f=FST(acceptor=acceptor,string_mapper=isymbols)
     else:

--- a/mfst/__init__.py
+++ b/mfst/__init__.py
@@ -935,7 +935,7 @@ class FST(object):
                 if arc.nextstate == -1:
                     continue
 
-                label = 'L:'
+                label = ''
                 if arc.input_label == 0:
                     label += '\u03B5'  # epsilon
                 else:
@@ -945,6 +945,7 @@ class FST(object):
                 else:
                     olabel = make_olabel(arc.output_label)
                 
+                print(label+' '+olabel)
                 if label != olabel:
                     label += ':'+olabel
                 

--- a/mfst/__init__.py
+++ b/mfst/__init__.py
@@ -940,12 +940,14 @@ class FST(object):
                     label += '\u03B5'  # epsilon
                 else:
                     label += make_label(arc.input_label)
-                if arc.input_label != arc.output_label:
-                    label += ':'
-                    if arc.output_label == 0:
-                        label += '\u03B5'
-                    else:
-                        label += make_olabel(arc.output_label)
+                if arc.output_label == 0:
+                    olabel = '\u03B5'  # epsilon
+                else:
+                    olabel = make_olabel(arc.output_label)
+                
+                if label != olabel:
+                    label += ':'+olabel
+                
                 if one != arc.weight:
                     label += f'/{arc.weight}'
                 to[arc.nextstate].append(label)

--- a/mfst/__init__.py
+++ b/mfst/__init__.py
@@ -927,7 +927,7 @@ class FST(object):
             else:
                 make_olabel = self._output_string_mapper
         else:
-            make_olabel = str
+            make_olabel = make_label
 
         for sid in range(self.num_states):
             to = defaultdict(list)
@@ -935,7 +935,7 @@ class FST(object):
                 if arc.nextstate == -1:
                     continue
 
-                label = ''
+                label = 'L:'
                 if arc.input_label == 0:
                     label += '\u03B5'  # epsilon
                 else:

--- a/mfst/__init__.py
+++ b/mfst/__init__.py
@@ -945,7 +945,6 @@ class FST(object):
                 else:
                     olabel = make_olabel(arc.output_label)
                 
-                print(label+' '+olabel)
                 if label != olabel:
                     label += ':'+olabel
                 
@@ -1107,8 +1106,7 @@ def compiler(strings,isymbols=None,osymbols=None,acceptor=False,add_symbols=True
         isymbols=SymbolTable(mutableOnFly=add_symbols)
         isymbols.add_symbol("-")
     if add_symbols and not acceptor and osymbols is None:
-        osymbols=SymbolTable(mutableOnFly=add_symbols)
-        osymbols.add_symbol("-")
+        osymbols=isymbols   #  this is to handle bug in printing
 
     if (acceptor):
         f=FST(acceptor=acceptor,string_mapper=isymbols)


### PR DESCRIPTION
Hi,

I've got three changes for consideration.  I'm looking for feedback on approach, and I need to comment the code better, but I thought it would be better to get early feedback before I comment.  Feel free to reject this if I am breaking style.

1) I added a SymbolTable class, which is callable so it can act as a string_mapper but also allows for two-way lookup and dynamic allocation of symbols.

2) I allow for different symbol maps in the input and output side, as in standard OpenFst.  This also required changing the check for input/output matching in jupyter output.

3) I created a compiler function which replicates fstcompile.  This is the biggest question: should this actually be a function in the FST class? 

Feedback on approach is appreciated.

(and apologies for all of the commits - the only way I could test was within Colab so I had to push debugging out to GitHub, which wasn't pretty.)

-Eric